### PR TITLE
NN-3523: refactors table to view model and adds table data model for remove restricted patient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2959,6 +2959,11 @@
         "@types/node": "*"
       }
     },
+    "@types/validator": {
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
+    },
     "@types/yargs": {
       "version": "15.0.9",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
@@ -3903,6 +3908,16 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
       "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+    },
+    "class-validator": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "requires": {
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -9130,6 +9145,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.22.tgz",
+      "integrity": "sha512-nE0aF0wrNq09ewF36s9FVqRW73hmpw6cobVDlbexmsu1432LEfuN24BCudNuRx4t2rElSeK/N0JbedzRW/TC4A=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -12206,6 +12226,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",
     "class-transformer": "^0.3.1",
+    "class-validator": "^0.13.1",
     "compression": "^1.7.4",
     "connect-flash": "^0.1.1",
     "connect-redis": "^6.0.0",

--- a/server/@types/SearchForm.ts
+++ b/server/@types/SearchForm.ts
@@ -1,0 +1,9 @@
+import { Expose, Transform } from 'class-transformer'
+import { IsNotEmpty } from 'class-validator'
+
+export default class SearchForm {
+  @Expose()
+  @Transform(value => value && JSON.stringify(value)?.replace(/"/g, ''))
+  @IsNotEmpty({ message: 'Enter a restricted patient’s name or prison number' })
+  searchTerm?: string
+}

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -18,6 +18,10 @@ export declare global {
       authSource: string
     }
 
+    interface Response {
+      internalRedirect(url: string): void
+    }
+
     interface Request {
       verified?: boolean
     }

--- a/server/@types/govuk/index.d.ts
+++ b/server/@types/govuk/index.d.ts
@@ -1,0 +1,21 @@
+declare namespace govuk {
+  namespace table {
+    interface TextCell {
+      text: string
+      attributes?: Record<string, string>
+    }
+
+    interface HTMLCell {
+      html: string
+      attributes?: Record<string, string>
+    }
+
+    type Cell = TextCell | HTMLCell
+
+    interface Table {
+      head: Cell[]
+      rows: Cell[][]
+      attributes?: Record<string, string>
+    }
+  }
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,7 @@ import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
 import { Services } from './services'
+import internalRedirectMiddleware from './middleware/internalRedirectMiddleware'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -31,6 +32,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())
   app.use(setUpWebRequestParsing())
+  app.use(internalRedirectMiddleware)
   app.use(setUpStaticResources())
   nunjucksSetup(app, path)
   app.use(setUpAuthentication())

--- a/server/middleware/flashMiddleware.test.ts
+++ b/server/middleware/flashMiddleware.test.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from 'express'
+import checkFlashForErrors from './flashMiddleware'
+
+const flashMock = jest.fn()
+
+const req = { flash: flashMock, body: { reportType: 'counterCorruptionReport' } } as unknown as Request
+const res = { redirect: jest.fn(), locals: {} } as unknown as Response
+const next = jest.fn()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  res.locals = {}
+})
+
+describe('flashMessageMiddleware', () => {
+  it('should call next if no errors', async () => {
+    checkFlashForErrors(req, res, next)
+    expect(res.locals).toEqual({})
+    expect(next).toBeCalledTimes(1)
+  })
+
+  it('should set validation errors if they exist', async () => {
+    flashMock
+      .mockReturnValueOnce([JSON.stringify({ val: 'error' })])
+      .mockReturnValueOnce([JSON.stringify({ form: 'response' })])
+
+    checkFlashForErrors(req, res, next)
+    expect(res.locals).toEqual({ validationErrors: { val: 'error' }, formResponse: { form: 'response' } })
+    expect(next).toBeCalledTimes(1)
+  })
+})

--- a/server/middleware/flashMiddleware.ts
+++ b/server/middleware/flashMiddleware.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from 'express'
+
+const flashMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  const validationErrorsMessage = req.flash('formErrors') || []
+  const validationErrors = validationErrorsMessage[0] || null
+
+  const formResponsesMessage = req.flash('formResponse') || []
+  const formResponse = formResponsesMessage[0] || null
+
+  if (validationErrors) {
+    res.locals.validationErrors = JSON.parse(validationErrors)
+    res.locals.formResponse = JSON.parse(formResponse)
+  }
+
+  return next()
+}
+
+export default flashMiddleware

--- a/server/middleware/internalRedirectMiddleware.test.ts
+++ b/server/middleware/internalRedirectMiddleware.test.ts
@@ -1,0 +1,31 @@
+import 'reflect-metadata'
+import { Request, Response } from 'express'
+import internalRedirectMiddleware from './internalRedirectMiddleware'
+
+describe('internalRedirectMiddleware', () => {
+  it('should apply internalRedirect on to the response and call next', () => {
+    const next = jest.fn()
+    const res = {} as Response
+    const req = {} as Request
+
+    internalRedirectMiddleware(req, res, next)
+
+    expect(res.internalRedirect).toEqual(expect.any(Function))
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  describe('internalRedirect', () => {
+    it('should prepend the base url to the path and redirect', () => {
+      const redirectMock = jest.fn()
+      const res = { redirect: redirectMock as unknown } as Response
+      const baseUrl = '/my-base-url'
+      const req = { baseUrl: `${baseUrl}/////` } as Request
+      const url = 'child-path'
+
+      internalRedirectMiddleware(req, res, jest.fn())
+
+      res.internalRedirect(`////${url}////`)
+      expect(redirectMock).toHaveBeenCalledWith(`${baseUrl}/${url}/`)
+    })
+  })
+})

--- a/server/middleware/internalRedirectMiddleware.ts
+++ b/server/middleware/internalRedirectMiddleware.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express'
+import { stripDuplicateSlashes } from '../utils/utils'
+
+export default (req: Request, res: Response, next: NextFunction): void => {
+  res.internalRedirect = (url: string) => res.redirect(stripDuplicateSlashes(`${req.baseUrl}/${url}`))
+  next()
+}

--- a/server/middleware/requestValidationMiddleware.test.ts
+++ b/server/middleware/requestValidationMiddleware.test.ts
@@ -1,0 +1,96 @@
+// eslint-disable-next-line max-classes-per-file
+import 'reflect-metadata'
+import { Request, Response } from 'express'
+import { IsNotEmpty, ValidateNested } from 'class-validator'
+import { Expose, Type } from 'class-transformer'
+import validationMiddleware from './requestValidationMiddleware'
+
+describe('validationMiddleware', () => {
+  describe('middleware', () => {
+    const notEmptyMessage = 'not empty'
+
+    class DummyChild {
+      @Expose()
+      @IsNotEmpty({ message: notEmptyMessage })
+      name: string
+    }
+
+    class DummyForm {
+      @Expose()
+      @IsNotEmpty({ message: notEmptyMessage })
+      id: string
+
+      @Expose()
+      @ValidateNested()
+      @Type(() => DummyChild)
+      child: DummyChild
+    }
+
+    it('should call next when there are no validation errors', async () => {
+      const next = jest.fn()
+      const req = {
+        body: {
+          id: 'abc',
+          child: { name: 'def' },
+        },
+      } as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm)(req, res, next)
+
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return flash responses', async () => {
+      const next = jest.fn()
+      const req = {
+        flash: jest.fn(),
+        body: {
+          id: '',
+          child: { name: 'def' },
+        },
+      } as unknown as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm)(req, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(req.flash).toHaveBeenCalledWith('formErrors', JSON.stringify([{ field: 'id', message: notEmptyMessage }]))
+      expect(req.flash).toHaveBeenCalledWith('formResponse', JSON.stringify(req.body))
+    })
+
+    it('should return the top level property on the error messages', async () => {
+      const next = jest.fn()
+      const req = {
+        flash: jest.fn(),
+        body: {
+          id: 'abc',
+          child: { name: '' },
+        },
+      } as unknown as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm)(req, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(req.flash).toHaveBeenCalledWith(
+        'formErrors',
+        JSON.stringify([{ field: 'child', message: notEmptyMessage }])
+      )
+    })
+
+    it('should should use provided redirect function on error', async () => {
+      const next = jest.fn()
+      const req = {
+        flash: jest.fn(),
+        body: {
+          id: 'abc',
+          child: { name: '' },
+        },
+      } as unknown as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      const redirect = jest.fn()
+      await validationMiddleware(DummyForm, redirect)(req, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(redirect).toHaveBeenCalledWith(req, res)
+    })
+  })
+})

--- a/server/middleware/requestValidationMiddleware.ts
+++ b/server/middleware/requestValidationMiddleware.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { plainToClass } from 'class-transformer'
+import { validate, ValidationError } from 'class-validator'
+
+export type ValidationErrorResponse = { field: string; message: string }
+
+const validationMiddleware = (
+  type: new () => unknown,
+  redirect = (req: Request, res: Response) => res.redirect('back')
+): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const body = plainToClass(type, req.body, { excludeExtraneousValues: true }) as {}
+    const errors: ValidationError[] = await validate(body)
+    if (errors.length === 0) {
+      return next()
+    }
+
+    const addError = (error: ValidationError, constraints: Record<string, string>): ValidationErrorResponse => ({
+      field: error.property,
+      message: Object.values(constraints).join(),
+    })
+
+    const mapErrors = (error: ValidationError) =>
+      error.children.length <= 0
+        ? addError(error, error.constraints)
+        : error.children.map((childError: ValidationError) => addError(error, childError.constraints))
+
+    req.flash('formErrors', JSON.stringify(errors.flatMap(mapErrors)))
+    req.flash('formResponse', JSON.stringify(req.body))
+
+    return redirect(req, res)
+  }
+}
+
+export default validationMiddleware

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -1,7 +1,6 @@
 import type { Router } from 'express'
 import express from 'express'
 import passport from 'passport'
-import flash from 'connect-flash'
 import config from '../config'
 import auth from '../authentication/auth'
 
@@ -12,7 +11,6 @@ export default function setUpAuth(): Router {
 
   router.use(passport.initialize())
   router.use(passport.session())
-  router.use(flash())
 
   router.get('/autherror', (req, res) => {
     res.status(401)

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -4,6 +4,7 @@ import connectRedis from 'connect-redis'
 import addRequestId from 'express-request-id'
 import express, { Router } from 'express'
 
+import flash from 'connect-flash'
 import config from '../config'
 
 const RedisStore = connectRedis(session)
@@ -36,6 +37,7 @@ export default function setUpWebSession(): Router {
   })
 
   router.use(addRequestId())
+  router.use(flash())
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,6 +8,11 @@ import viewPatientSearchRoutes from './viewPatientSearch'
 import viewPatientsRoutes from './viewPatients'
 
 import { Services } from '../services'
+import {
+  removeRestrictedPatientsSearchResultRoutes,
+  searchForARestrictedPatientRoutes,
+} from './removeRestrictedPatient'
+import { RemoveRestrictedPatientPath } from './removeRestrictedPatient/constants'
 
 export default function routes(
   router: Router,
@@ -19,6 +24,14 @@ export default function routes(
   router.use('/move-to-hospital', movePrisonerRoutes({ movePrisonerService, prisonerSearchService }))
   router.use('/search-for-restricted-patient', viewPatientSearchRoutes())
   router.use('/viewing-restricted-patients', viewPatientsRoutes({ restrictedPatientSearchService }))
+  router.use(
+    RemoveRestrictedPatientPath.DisplaySearch,
+    searchForARestrictedPatientRoutes({ restrictedPatientSearchService })
+  )
+  router.use(
+    RemoveRestrictedPatientPath.SearchResults,
+    removeRestrictedPatientsSearchResultRoutes({ restrictedPatientSearchService })
+  )
 
   return router
 }

--- a/server/routes/removeRestrictedPatient/RemoveRestrictedPatientRoutes.test.ts
+++ b/server/routes/removeRestrictedPatient/RemoveRestrictedPatientRoutes.test.ts
@@ -1,0 +1,149 @@
+import 'reflect-metadata'
+import { Request, Response } from 'express'
+import RemoveRestrictedPatientRoutes from './RemoveRestrictedPatientRoutes'
+import RestrictedPatientSearchService, {
+  RestrictedPatientSearchSummary,
+} from '../../services/restrictedPatientSearchService'
+import HmppsAuthClient from '../../data/hmppsAuthClient'
+import { RemoveRestrictedPatientPath } from './constants'
+
+jest.mock('../../services/restrictedPatientSearchService')
+
+describe('RemoveRestrictedPatientRoutes', () => {
+  let res: Response
+  let req: Request
+  let restrictedPatientSearchService: RestrictedPatientSearchService
+  let routes: RemoveRestrictedPatientRoutes
+  beforeEach(() => {
+    res = {
+      render: jest.fn(),
+      internalRedirect: jest.fn(),
+    } as unknown as Response
+    req = {} as Request
+    restrictedPatientSearchService = new RestrictedPatientSearchService(jest.fn() as unknown as HmppsAuthClient)
+    routes = new RemoveRestrictedPatientRoutes(restrictedPatientSearchService)
+  })
+
+  describe('displaySearch', () => {
+    it('should render the expected template with the correct for action', () => {
+      routes.displaySearch(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/patientSearch', {
+        action: RemoveRestrictedPatientPath.SearchResults,
+      })
+    })
+  })
+
+  describe('searchFormRedirect', () => {
+    it('should redirect with the search term from the body as a query', () => {
+      req.body = {
+        searchTerm: 'abc',
+      }
+      routes.searchFormRedirect(req, res)
+      expect(res.internalRedirect).toHaveBeenCalledWith('?searchTerm=abc')
+    })
+  })
+
+  describe('displaySearchResults', () => {
+    it('should redirect to search page if there is no search term query', async () => {
+      req.query = {
+        searchTerm: '',
+      }
+      await routes.displaySearchResults(req, res)
+      expect(res.internalRedirect).toHaveBeenCalledWith(RemoveRestrictedPatientPath.DisplaySearch)
+    })
+
+    it('should search for patients if there is a search term query', async () => {
+      req.query = {
+        searchTerm: 'abc',
+      }
+      res.locals = {
+        user: 'user-1',
+      }
+      await routes.displaySearchResults(req, res)
+      expect(restrictedPatientSearchService.search).toHaveBeenCalledWith({ searchTerm: 'abc' }, 'user-1')
+    })
+
+    it('should render the expected template with data', async () => {
+      jest.spyOn(restrictedPatientSearchService, 'search').mockResolvedValue([
+        {
+          alerts: [
+            { alertType: 'T', alertCode: 'TCPA' },
+            { alertType: 'X', alertCode: 'XCU' },
+          ],
+          cellLocation: '1-2-015',
+          displayName: 'Smith, John',
+          prisonerNumber: 'A1234AA',
+          prisonName: 'HMP Moorland',
+          supportingPrisonId: 'DNI',
+          dischargedHospitalId: 'YEWTHO',
+          dischargedHospitalDescription: 'Yew Trees',
+          dischargeDate: '2021-06-08',
+          dischargeDetails: 'Psychiatric Hospital Discharge to Yew Trees',
+        } as RestrictedPatientSearchSummary,
+      ])
+      req.query = {
+        searchTerm: 'abc',
+      }
+      res.locals = {
+        user: 'user-1',
+      }
+      const heading = 'Select a restricted patient'
+      await routes.displaySearchResults(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/viewPatients', {
+        tableData: {
+          attributes: {
+            'data-test': 'patient-search-results-table',
+            'data-module': 'moj-sortable-table',
+          },
+          head: [
+            {
+              html: '<span class="govuk-visually-hidden">Picture</span>',
+            },
+            {
+              text: 'Name',
+              attributes: {
+                'aria-sort': 'ascending',
+              },
+            },
+            {
+              text: 'Prison number',
+            },
+            {
+              text: 'Hospital',
+              attributes: {
+                'aria-sort': 'none',
+              },
+            },
+            {
+              text: '',
+            },
+          ],
+          rows: [
+            [
+              {
+                html: '<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />',
+              },
+              {
+                html: '<a href="http://localhost:3002/prisoner/A1234AA" class="govuk-link">Smith, John</a>',
+              },
+              {
+                text: 'A1234AA',
+              },
+              {
+                text: 'Yew Trees',
+              },
+              {
+                html: `<a href="/person-removed/A1234AA" class="govuk-link" data-test="remove-restricted-patient-link">
+                <span class="govuk-visually-hidden">Smith, John - </span>Remove as a restricted patient
+              </a>`,
+              },
+            ],
+          ],
+        },
+        heading,
+        pageTitle: heading,
+        searchTerm: 'abc',
+      })
+    })
+  })
+})

--- a/server/routes/removeRestrictedPatient/RemoveRestrictedPatientRoutes.ts
+++ b/server/routes/removeRestrictedPatient/RemoveRestrictedPatientRoutes.ts
@@ -1,0 +1,52 @@
+import { Request, Response } from 'express'
+import { plainToClass } from 'class-transformer'
+import { URLSearchParams } from 'url'
+import SearchForm from '../../@types/SearchForm'
+import RestrictedPatientSearchService, {
+  RestrictedPatientSearchSummary,
+} from '../../services/restrictedPatientSearchService'
+import PatientSearchTableViewModel from '../../viewmodel/PatientSearchTableViewModel'
+import { RemoveRestrictedPatientPath } from './constants'
+
+export default class RemoveRestrictedPatientRoutes {
+  constructor(private readonly restrictedPatientSearchService: RestrictedPatientSearchService) {}
+
+  displaySearch = (req: Request, res: Response): void => {
+    res.render('pages/patientSearch', {
+      action: RemoveRestrictedPatientPath.SearchResults,
+    })
+  }
+
+  searchFormRedirect = async (req: Request, res: Response): Promise<void> => {
+    const { searchTerm } = plainToClass(SearchForm, req.body, { excludeExtraneousValues: true })
+    res.internalRedirect(`?${new URLSearchParams({ searchTerm })}`)
+  }
+
+  displaySearchResults = async (req: Request, res: Response): Promise<void> => {
+    const { searchTerm } = plainToClass(SearchForm, req.query, { excludeExtraneousValues: true })
+    if (!searchTerm) {
+      res.internalRedirect(RemoveRestrictedPatientPath.DisplaySearch)
+      return
+    }
+
+    const { user } = res.locals
+    const searchResults = await this.restrictedPatientSearchService.search({ searchTerm }, user)
+
+    const renderCTA = (prisoner: RestrictedPatientSearchSummary) => ({
+      html: `<a href="/person-removed/${prisoner.prisonerNumber}" class="govuk-link" data-test="remove-restricted-patient-link">
+                <span class="govuk-visually-hidden">${prisoner.displayName} - </span>Remove as a restricted patient
+              </a>`,
+    })
+
+    const tableViewModel = new PatientSearchTableViewModel(searchResults).addColumn({ text: '' }, renderCTA)
+
+    const heading = 'Select a restricted patient'
+
+    res.render('pages/viewPatients', {
+      tableData: tableViewModel.build(),
+      heading,
+      pageTitle: heading,
+      searchTerm,
+    })
+  }
+}

--- a/server/routes/removeRestrictedPatient/constants.ts
+++ b/server/routes/removeRestrictedPatient/constants.ts
@@ -1,0 +1,6 @@
+export const RemoveRestrictedPatientPath = {
+  DisplaySearch: '/search-for-a-restricted-patient',
+  SearchResults: '/select-restricted-patient',
+}
+
+export default { RemoveRestrictedPatientPath }

--- a/server/routes/removeRestrictedPatient/index.test.ts
+++ b/server/routes/removeRestrictedPatient/index.test.ts
@@ -1,0 +1,109 @@
+import { Express } from 'express'
+import request from 'supertest'
+import { RemoveRestrictedPatientPath } from './constants'
+import appWithAllRoutes from '../testutils/appSetup'
+import HmppsAuthClient from '../../data/hmppsAuthClient'
+import RestrictedPatientSearchService, {
+  RestrictedPatientSearchSummary,
+} from '../../services/restrictedPatientSearchService'
+
+jest.mock('../../services/restrictedPatientSearchService')
+
+let app: Express
+let restrictedPatientSearchService: RestrictedPatientSearchService
+
+beforeEach(() => {
+  restrictedPatientSearchService = new RestrictedPatientSearchService(jest.fn() as unknown as HmppsAuthClient)
+  app = appWithAllRoutes({ production: false }, { restrictedPatientSearchService })
+  jest.spyOn(restrictedPatientSearchService, 'search').mockResolvedValue([
+    {
+      alerts: [
+        { alertType: 'T', alertCode: 'TCPA' },
+        { alertType: 'X', alertCode: 'XCU' },
+      ],
+      cellLocation: '1-2-015',
+      displayName: 'Smith, John',
+      prisonerNumber: 'A1234AA',
+      prisonName: 'HMP Moorland',
+      supportingPrisonId: 'DNI',
+      dischargedHospitalId: 'YEWTHO',
+      dischargedHospitalDescription: 'Yew Trees',
+      dischargeDate: '2021-06-08',
+      dischargeDetails: 'Psychiatric Hospital Discharge to Yew Trees',
+    } as RestrictedPatientSearchSummary,
+  ])
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('removeRestrictedPatient', () => {
+  describe(`GET ${RemoveRestrictedPatientPath.DisplaySearch}`, () => {
+    it('should render a search form template', () => {
+      return request(app)
+        .get(RemoveRestrictedPatientPath.DisplaySearch)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Search for a restricted patient')
+          expect(res.text).toContain('data-test="patient-search-term-input">')
+          expect(res.text).toContain('data-test="patient-search-submit">')
+        })
+    })
+  })
+
+  describe(`POST ${RemoveRestrictedPatientPath.SearchResults}`, () => {
+    it(`should redirect to ${RemoveRestrictedPatientPath.DisplaySearch} if there is no searchTerm`, () => {
+      return request(app)
+        .post(RemoveRestrictedPatientPath.SearchResults)
+        .redirects(1)
+        .expect(res => {
+          expect(res.redirects.length).toBe(1)
+          expect(res.redirects[0]).toMatch(RemoveRestrictedPatientPath.DisplaySearch)
+        })
+    })
+
+    it(`should redirect to GET ${RemoveRestrictedPatientPath.SearchResults} if there is a searchTerm`, () => {
+      return request(app)
+        .post(RemoveRestrictedPatientPath.SearchResults)
+        .send({ searchTerm: 'abc' })
+        .redirects(1)
+        .expect(res => {
+          expect(res.redirects.length).toBe(1)
+          expect(res.redirects[0]).toMatch(RemoveRestrictedPatientPath.SearchResults)
+        })
+    })
+  })
+
+  describe(`GET ${RemoveRestrictedPatientPath.SearchResults}`, () => {
+    it(`should display search results is a search term is present`, () => {
+      return request(app)
+        .get(RemoveRestrictedPatientPath.SearchResults)
+        .query({ searchTerm: 'abc' })
+        .expect(res => {
+          expect(res.text).toContain('Select a restricted patient')
+          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 1</p>')
+          expect(res.text).toContain(
+            '<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />'
+          )
+          expect(res.text).toContain('Smith, John')
+          expect(res.text).toContain('Yew Trees')
+          expect(res.text).toContain(
+            `<a href="/person-removed/A1234AA" class="govuk-link" data-test="remove-restricted-patient-link">
+                <span class="govuk-visually-hidden">Smith, John - </span>Remove as a restricted patient
+              </a>`
+          )
+        })
+    })
+    it(`should display a fallback message for no results found`, () => {
+      jest.spyOn(restrictedPatientSearchService, 'search').mockResolvedValue([])
+      return request(app)
+        .get(RemoveRestrictedPatientPath.SearchResults)
+        .send({ searchTerm: 'abc' })
+        .query({ searchTerm: 'abc' })
+        .expect(res => {
+          expect(res.text).toContain('There are no results for the details you have entered.')
+        })
+    })
+  })
+})

--- a/server/routes/removeRestrictedPatient/index.ts
+++ b/server/routes/removeRestrictedPatient/index.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express'
+import flashMiddleware from '../../middleware/flashMiddleware'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+import requestValidationMiddleware from '../../middleware/requestValidationMiddleware'
+import SearchForm from '../../@types/SearchForm'
+import RestrictedPatientSearchService from '../../services/restrictedPatientSearchService'
+import RemoveRestrictedPatientRoutes from './RemoveRestrictedPatientRoutes'
+import { RemoveRestrictedPatientPath } from './constants'
+
+type Dependencies = { restrictedPatientSearchService: RestrictedPatientSearchService }
+
+export const searchForARestrictedPatientRoutes = (
+  { restrictedPatientSearchService }: Dependencies,
+  router: Router = Router()
+): Router => {
+  const routes = new RemoveRestrictedPatientRoutes(restrictedPatientSearchService)
+  router.get('/', flashMiddleware, asyncMiddleware(routes.displaySearch))
+  return router
+}
+
+export const removeRestrictedPatientsSearchResultRoutes = (
+  { restrictedPatientSearchService }: Dependencies,
+  router: Router = Router()
+): Router => {
+  const routes = new RemoveRestrictedPatientRoutes(restrictedPatientSearchService)
+  router.post(
+    '/',
+    requestValidationMiddleware(SearchForm, (_, res) => res.redirect(RemoveRestrictedPatientPath.DisplaySearch)),
+    asyncMiddleware(routes.searchFormRedirect)
+  )
+  router.get('/', asyncMiddleware(routes.displaySearchResults))
+  return router
+}

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -4,6 +4,7 @@ import cookieSession from 'cookie-session'
 import createError from 'http-errors'
 import path from 'path'
 
+import flash from 'connect-flash'
 import allRoutes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
@@ -14,6 +15,7 @@ import PrisonerSearchService from '../../services/prisonerSearchService'
 import MovePrisonerService from '../../services/movePrisonerService'
 import RestrictedPatientSearchService from '../../services/restrictedPatientSearchService'
 import { Services } from '../../services'
+import internalRedirectMiddleware from '../../middleware/internalRedirectMiddleware'
 
 const user = {
   name: 'john smith',
@@ -51,8 +53,10 @@ function appSetup(route: Router, production: boolean): Express {
   })
 
   app.use(cookieSession({ keys: [''] }))
+  app.use(flash())
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
+  app.use(internalRedirectMiddleware)
   app.use('/', route)
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(production))

--- a/server/routes/viewPatientSearch/index.ts
+++ b/server/routes/viewPatientSearch/index.ts
@@ -1,18 +1,22 @@
-import express, { RequestHandler, Router } from 'express'
+import express, { Router } from 'express'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 import PatientSearchRoutes from './patientSearch'
+import flashMiddleware from '../../middleware/flashMiddleware'
+import requestValidationMiddleware from '../../middleware/requestValidationMiddleware'
+import SearchForm from '../../@types/SearchForm'
 
 export default function viewPatientRoutes(): Router {
   const router = express.Router()
 
   const patientSearch = new PatientSearchRoutes()
 
-  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
-
-  get('/', patientSearch.view)
-  post('/', patientSearch.submit)
+  router.get('/', flashMiddleware, asyncMiddleware(patientSearch.view))
+  router.post(
+    '/',
+    requestValidationMiddleware(SearchForm, (_, res) => res.internalRedirect('/')),
+    asyncMiddleware(patientSearch.submit)
+  )
 
   return router
 }

--- a/server/routes/viewPatientSearch/patientSearch.test.ts
+++ b/server/routes/viewPatientSearch/patientSearch.test.ts
@@ -12,34 +12,35 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /search-for-restricted-patient', () => {
-  it('should load the search for a restricted patient page', () => {
-    return request(app)
-      .get('/search-for-restricted-patient')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('Search for a restricted patient')
-        expect(res.text).toContain('Enter a restricted patient’s name or prison number')
-      })
-  })
-})
-
-describe('POST /search-for-restricted-patient', () => {
-  it('should redirect to select restricted patient page with the correct search text', () => {
-    return request(app)
-      .post('/search-for-restricted-patient')
-      .send({ searchTerm: 'Smith' })
-      .expect('Location', '/viewing-restricted-patients?searchTerm=Smith')
+describe('/search-for-restricted-patient', () => {
+  describe('GET /search-for-restricted-patient', () => {
+    it('should load the search for a restricted patient page', () => {
+      return request(app)
+        .get('/search-for-restricted-patient')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Search for a restricted patient')
+          expect(res.text).toContain('Enter a restricted patient’s name or prison number')
+        })
+    })
   })
 
-  it('should render validation messages', () => {
-    return request(app)
-      .post('/search-for-restricted-patient')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('Error: Search for a restricted patient')
-        expect(res.text).toContain('There is a problem')
-        expect(res.text).toContain('Enter a restricted patient’s name or prison number')
-      })
+  describe('POST /search-for-restricted-patient', () => {
+    it('should redirect to select restricted patient page with the correct search text', () => {
+      return request(app)
+        .post('/search-for-restricted-patient')
+        .send({ searchTerm: 'Smith' })
+        .expect('Location', '/viewing-restricted-patients?searchTerm=Smith')
+    })
+
+    it('should redirect back to search-for-restricted-patient', () => {
+      return request(app)
+        .post('/search-for-restricted-patient')
+        .redirects(1)
+        .expect(res => {
+          expect(res.redirects.length).toBe(1)
+          expect(res.redirects[0]).toMatch('/search-for-restricted-patient')
+        })
+    })
   })
 })

--- a/server/routes/viewPatientSearch/patientSearch.ts
+++ b/server/routes/viewPatientSearch/patientSearch.ts
@@ -1,24 +1,18 @@
 import url from 'url'
 import { Request, Response } from 'express'
-import validateForm from './patientSearchValidation'
+import { plainToClass } from 'class-transformer'
 import { FormError } from '../../@types/template'
+import SearchForm from '../../@types/SearchForm'
 
 export default class PatientSearchRoutes {
   private renderView = async (req: Request, res: Response, error?: FormError): Promise<void> => {
-    return res.render('pages/patientSearch', {
-      errors: error ? [error] : [],
-    })
+    return res.render('pages/patientSearch')
   }
 
   view = async (req: Request, res: Response): Promise<void> => this.renderView(req, res)
 
   submit = async (req: Request, res: Response): Promise<void> => {
-    const { searchTerm } = req.body
-
-    const error = validateForm({ searchTerm })
-
-    if (error) return this.renderView(req, res, error)
-
+    const { searchTerm } = plainToClass(SearchForm, req.body, { excludeExtraneousValues: true })
     return res.redirect(
       url.format({
         pathname: '/viewing-restricted-patients',

--- a/server/routes/viewPatientSearch/patientSearchValidation.ts
+++ b/server/routes/viewPatientSearch/patientSearchValidation.ts
@@ -1,8 +1,5 @@
 import { FormError } from '../../@types/template'
-
-type SearchForm = {
-  searchTerm?: string
-}
+import SearchForm from '../../@types/SearchForm'
 
 const errors: { [key: string]: FormError } = {
   MISSING_TEXT: {

--- a/server/routes/viewPatients/index.ts
+++ b/server/routes/viewPatients/index.ts
@@ -1,9 +1,12 @@
-import express, { RequestHandler, Router } from 'express'
+import express, { Router } from 'express'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 import RestrictedPatientSearchService from '../../services/restrictedPatientSearchService'
 
 import ViewPatientsRoutes from './viewPatients'
+import flashMiddleware from '../../middleware/flashMiddleware'
+import requestValidationMiddleware from '../../middleware/requestValidationMiddleware'
+import SearchForm from '../../@types/SearchForm'
 
 export default function viewPatientsRoutes({
   restrictedPatientSearchService,
@@ -14,11 +17,12 @@ export default function viewPatientsRoutes({
 
   const viewPatients = new ViewPatientsRoutes(restrictedPatientSearchService)
 
-  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
-
-  get('/', viewPatients.view)
-  post('/', viewPatients.submit)
+  router.get('/', flashMiddleware, asyncMiddleware(viewPatients.view))
+  router.post(
+    '/',
+    requestValidationMiddleware(SearchForm, (_, res) => res.redirect('/search-for-restricted-patient')),
+    asyncMiddleware(viewPatients.submit)
+  )
 
   return router
 }

--- a/server/routes/viewPatients/viewPatients.test.ts
+++ b/server/routes/viewPatients/viewPatients.test.ts
@@ -44,7 +44,7 @@ describe('GET /viewing-restricted-patients', () => {
       ])
     })
 
-    it('should load the viewing rstricted patients page', () => {
+    it('should load the viewing restricted patients page', () => {
       return request(app)
         .get('/viewing-restricted-patients?searchTerm=Smith')
         .expect('Content-Type', /html/)
@@ -52,12 +52,14 @@ describe('GET /viewing-restricted-patients', () => {
           expect(res.text).toContain('Viewing restricted patients')
           expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 1</p>')
           expect(res.text).toContain(
-            '<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />'
+            `<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />`
           )
           expect(res.text).toContain('Smith, John')
           expect(res.text).toContain('Yew Trees')
           expect(res.text).toContain(
-            '<a href="http://localhost:3002/prisoner/A1234AA/add-case-note" class="govuk-link" data-test="patient-add-case-note-link"><span class="govuk-visually-hidden">Smith, John - </span>Add a case note</a>'
+            `<a href="http://localhost:3002/prisoner/A1234AA/add-case-note" class="govuk-link" data-test="patient-add-case-note-link">
+                <span class="govuk-visually-hidden">Smith, John - </span>Add a case note
+              </a>`
           )
         })
     })
@@ -74,9 +76,7 @@ describe('GET /viewing-restricted-patients', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain('Viewing restricted patients')
-          expect(res.text).toContain(
-            'There are no results for the name or number you have entered. You can search again.'
-          )
+          expect(res.text).toContain('There are no results for the details you have entered.')
         })
     })
   })
@@ -90,14 +90,13 @@ describe('POST /viewing-restricted-patients', () => {
       .expect('Location', '/viewing-restricted-patients?searchTerm=Smith')
   })
 
-  it('should render validation messages', () => {
+  it('should redirect back to search-for-restricted-patient', () => {
     return request(app)
-      .post('/viewing-restricted-patients')
-      .expect('Content-Type', /html/)
+      .post('/search-for-restricted-patient')
+      .redirects(1)
       .expect(res => {
-        expect(res.text).toContain('Error: Viewing restricted patients')
-        expect(res.text).toContain('There is a problem')
-        expect(res.text).toContain('Enter a restricted patient’s name or prison number')
+        expect(res.redirects.length).toBe(1)
+        expect(res.redirects[0]).toMatch('/search-for-restricted-patient')
       })
   })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import * as pathModule from 'path'
 import { FormError } from '../@types/template'
 import config from '../config'
+import { ValidationErrorResponse } from '../middleware/requestValidationMiddleware'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -56,6 +57,24 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       }
     }
     return null
+  })
+
+  njkEnv.addFilter('formError', (array: ValidationErrorResponse[], formFieldId) => {
+    if (!array || !formFieldId) return null
+    const item = array.find(error => error.field === formFieldId)
+    if (item) {
+      return {
+        text: item.message.split(',')[0],
+      }
+    }
+    return null
+  })
+
+  njkEnv.addFilter('asErrorSummary', (array: ValidationErrorResponse[] = []) => {
+    return array.map(error => ({
+      text: error.message.split(',')[0],
+      href: `#${error.field}`,
+    }))
   })
 
   njkEnv.addGlobal('pshUrl', config.pshUrl)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -21,4 +21,9 @@ export const addSelect = (selectItems: SelectOption[], text = 'Select'): SelectO
   ...selectItems,
 ]
 
+export const stripDuplicateSlashes = (value: string): string => {
+  const pathSeparatorPattern = /(\/)\/+/g
+  return value.replace(pathSeparatorPattern, '$1')
+}
+
 export default convertToTitleCase

--- a/server/viewmodel/PatientSearchTableViewModel.ts
+++ b/server/viewmodel/PatientSearchTableViewModel.ts
@@ -1,0 +1,39 @@
+import TableViewModel from './TableViewModel'
+import { RestrictedPatientSearchSummary } from '../services/restrictedPatientSearchService'
+import config from '../config'
+
+export default class PatientSearchTableViewModel extends TableViewModel<RestrictedPatientSearchSummary> {
+  constructor(items: RestrictedPatientSearchSummary[]) {
+    super(items, {
+      'data-test': 'patient-search-results-table',
+      'data-module': 'moj-sortable-table',
+    })
+
+    this.addColumn({ html: '<span class="govuk-visually-hidden">Picture</span>' }, this.renderImage)
+      .addColumn({ text: 'Name', attributes: { 'aria-sort': 'ascending' } }, this.renderDisplayName)
+      .addColumn({ text: 'Prison number' }, this.renderPrisonNumber)
+      .addColumn({ text: 'Hospital', attributes: { 'aria-sort': 'none' } }, this.renderLocation)
+  }
+
+  private renderPrisonNumber(prisoner: RestrictedPatientSearchSummary) {
+    return { text: prisoner.prisonerNumber }
+  }
+
+  private renderImage(prisoner: RestrictedPatientSearchSummary) {
+    return {
+      html: `<img src="/prisoner/${prisoner.prisonerNumber}/image" alt="Photograph of ${prisoner.displayName}" class="results-table__image" />`,
+    }
+  }
+
+  private renderDisplayName(prisoner: RestrictedPatientSearchSummary) {
+    return {
+      html: `<a href="${config.pshUrl}/prisoner/${prisoner.prisonerNumber}" class="govuk-link">${prisoner.displayName}</a>`,
+    }
+  }
+
+  private renderLocation(prisoner: RestrictedPatientSearchSummary) {
+    return {
+      text: prisoner.dischargedHospitalDescription,
+    }
+  }
+}

--- a/server/viewmodel/TableViewModel.test.ts
+++ b/server/viewmodel/TableViewModel.test.ts
@@ -1,0 +1,60 @@
+import TableViewModel from './TableViewModel'
+
+describe('TableViewModel', () => {
+  const item: Readonly<{ bar: string; foo: string }> = Object.freeze({
+    foo: 'bar',
+    bar: 'foo',
+  })
+  const data = Array.from({ length: 2 }).fill(item) as Readonly<{ bar: string; foo: string }>[]
+
+  it('should initialise with empty headers, rows and attributes', () => {
+    const tableViewModel = new TableViewModel()
+    const actual = tableViewModel.build()
+    expect(actual.head).toHaveLength(0)
+    expect(actual.rows).toHaveLength(0)
+    expect(actual.attributes).toBeUndefined()
+  })
+
+  it('should add attributes to the results', () => {
+    const attributes = { 'data-test': 'my-attrib' }
+    const tableViewModel = new TableViewModel([], attributes)
+    const actual = tableViewModel.build()
+    expect(actual.attributes).toBe(attributes)
+  })
+
+  it('should return headers and rows', () => {
+    const tableViewModel = new TableViewModel(data)
+
+    const headOne = { html: '<span>My Foo</span>' }
+    const headTwo = { text: 'My Bar' }
+    tableViewModel
+      .addColumn(headOne, (val, index) => ({
+        text: `My ${val.foo} ${index}`,
+      }))
+      .addColumn(headTwo, (val, index) => ({
+        html: `My ${val.bar} ${index}`,
+      }))
+
+    const actual = tableViewModel.build()
+
+    expect(actual.head).toEqual([headOne, headTwo])
+    expect(actual.rows).toEqual([
+      [
+        {
+          text: `My bar 0`,
+        },
+        {
+          html: `My foo 0`,
+        },
+      ],
+      [
+        {
+          text: `My bar 1`,
+        },
+        {
+          html: `My foo 1`,
+        },
+      ],
+    ])
+  })
+})

--- a/server/viewmodel/TableViewModel.ts
+++ b/server/viewmodel/TableViewModel.ts
@@ -1,0 +1,25 @@
+export default class TableViewModel<T> {
+  private head: govuk.table.Cell[] = []
+
+  private renders: Array<(data: T, index: number) => govuk.table.Cell> = []
+
+  constructor(private readonly items: T[] = [], private readonly attributes?: Record<string, string>) {}
+
+  addColumn(head: govuk.table.Cell, render: (data: T, index: number) => govuk.table.Cell): TableViewModel<T> {
+    this.head.push(head)
+    this.renders.push(render)
+    return this
+  }
+
+  build(): govuk.table.Table {
+    const rows =
+      this.renders.length === this.head.length
+        ? this.items.map((item, index) => this.renders.map(renderer => renderer(item, index)))
+        : []
+    return {
+      attributes: this.attributes,
+      head: this.head,
+      rows,
+    }
+  }
+}

--- a/server/views/pages/patientSearch.njk
+++ b/server/views/pages/patientSearch.njk
@@ -12,10 +12,10 @@
 {% endblock %}
 
 {% block content %}
-  {% if errors | length %}
+  {% if validationErrors | length %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
-      errorList: errors,
+      errorList: validationErrors | asErrorSummary,
       attributes: { "data-test": "error-summary" }
     }) }}
   {% endif %}

--- a/server/views/pages/viewPatients.njk
+++ b/server/views/pages/viewPatients.njk
@@ -8,7 +8,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% set title = "Viewing restricted patients" %}
+{% set title = pageTitle or "Viewing restricted patients" %}
 
 {% block beforeContent %}
   {{ breadcrumb() }}
@@ -23,64 +23,19 @@
     }) }}
   {% endif %}
 
-  <h1 class="govuk-heading-l">Restricted patients</h1>
+  <h1 class="govuk-heading-l">{{ heading or "Restricted patients" }}</h1>
   
   {% include "../partials/patientSearchForm.njk" %}
 
-  {% set rows = [] %}
-  {% for prisoner in searchResults %}
-    {% set prisonerImageHtml %}
-      <img src="/prisoner/{{ prisoner.prisonerNumber }}/image" alt="Photograph of {{ prisoner.displayName }}" class="results-table__image" />
-    {% endset -%}
-    {% set prisonerLinkHtml %}
-      <a href="{{ pshUrl }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisoner.displayName }}</a>
-    {% endset -%}
-    {% set addCaseNoteLinkHtml %}
-      <a href="{{ pshUrl }}/prisoner/{{ prisoner.prisonerNumber }}/add-case-note" class="govuk-link" data-test="patient-add-case-note-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Add a case note</a>
-    {% endset -%}
-    {% set rows = (rows.push([
-      { html: prisonerImageHtml },
-      {
-        html: prisonerLinkHtml,
-        attributes: {
-          "data-sort-value": prisoner.displayName
-        }
-      },
-      { text: prisoner.prisonerNumber },
-      { text: prisoner.dischargedHospitalDescription },
-      { html: addCaseNoteLinkHtml }
-    ]), rows) %}
-  {% endfor %}
-
-  {% if rows | length %}
-    <p class="align-right"><strong>People listed:</strong> {{ rows.length }}</p>
+  {% if tableData.rows | length %}
+    <p class="align-right"><strong>People listed:</strong> {{ tableData.rows.length }}</p>
 
     <div class="results-table">
-      {{ govukTable({
-        head: [
-          { html: '<span class="govuk-visually-hidden">Picture</span>' },
-          {
-            text: "Name",
-            attributes: {
-              "aria-sort": "ascending"
-            }
-          },
-          { text: "Prison number" },
-          {
-            text: "Location",
-            attributes: {
-              "aria-sort": "none"
-            }
-          },
-          { text: "" }
-        ],
-        rows: rows,
-        attributes: { "data-test": "patient-search-results-table", "data-module": "moj-sortable-table" }
-      }) }}
+      {{ govukTable(tableData) }}
     </div>
   {% else %}
     {% if not errors | length %}
-      <p class="govuk-!-padding-top-3" data-test="no-results-message">There are no results for the name or number you have entered. You can search again.</p>
+      <p class="govuk-!-padding-top-3" data-test="no-results-message">There are no results for the details you have entered.</p>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/server/views/partials/patientSearchForm.njk
+++ b/server/views/partials/patientSearchForm.njk
@@ -1,4 +1,4 @@
-<form method="POST" novalidate="novalidate" data-test="prisoner-search-form">
+<form method="POST" action="{{ action }}" novalidate="novalidate" data-test="prisoner-search-form">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
   <div class="horizontal-form govuk-!-margin-bottom-3">
@@ -13,7 +13,7 @@
       attributes: {
         'data-test': "patient-search-term-input"
       },
-      errorMessage: errors | findError("searchTerm")
+      errorMessage: validationErrors | formError("searchTerm")
 
     }) }}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
This PR:

- introduces the class-validator dependency to allow dto validations via ts annotations
- Adds the request validation middleware so that requests to paths can be validated in a standard way outside of a request handler
- updates the remove restricted patients url
- Decouples view and model for table search results template