### PR TITLE
SDI-381 include search misses

### DIFF
--- a/server/routes/addPatient/prisonerSelect.test.ts
+++ b/server/routes/addPatient/prisonerSelect.test.ts
@@ -59,6 +59,32 @@ describe('GET /select-prisoner', () => {
           indeterminateSentence: true,
           recall: false,
         } as PrisonerSearchSummary,
+        {
+          alerts: [],
+          locationDescription: 'Outside - released from Doncaster - discharged to NGH',
+          displayName: 'No move link - determinate sentence past CRD',
+          formattedAlerts: [],
+          prisonerNumber: 'A1234AC',
+          lastMovementTypeCode: 'REL',
+          lastMovementReasonCode: 'HP',
+          restrictedPatient: false,
+          indeterminateSentence: false,
+          recall: false,
+          conditionalReleaseDate: new Date(new Date().getDate() - 1),
+        } as PrisonerSearchSummary,
+        {
+          alerts: [],
+          locationDescription: 'Outside - released from Doncaster - discharged to NGH',
+          displayName: 'No move link - determinate recall past SED',
+          formattedAlerts: [],
+          prisonerNumber: 'A1234AD',
+          lastMovementTypeCode: 'REL',
+          lastMovementReasonCode: 'HP',
+          restrictedPatient: false,
+          indeterminateSentence: false,
+          recall: true,
+          sentenceExpiryDate: new Date(new Date().getDate() - 1),
+        } as PrisonerSearchSummary,
       ])
     })
 
@@ -78,7 +104,7 @@ describe('GET /select-prisoner', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain('Select a prisoner')
-          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 1</p>')
+          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 3</p>')
           expect(res.text).toContain(
             '<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />'
           )
@@ -87,6 +113,22 @@ describe('GET /select-prisoner', () => {
           expect(res.text).toContain('Controlled unlock')
           expect(res.text).toContain(
             '<a href="/add-restricted-patient/select-hospital?prisonerNumber=A1234AA&journeyStartUrl=/add-restricted-patient/select-prisoner?searchTerm=Smith" class="govuk-link" data-test="prisoner-add-restricted-patient-link"><span class="govuk-visually-hidden">Smith, John - </span>Add to restricted patients</a>'
+          )
+        })
+    })
+
+    it('should include post CRD and SED but without a move link', () => {
+      return request(app)
+        .get('/add-restricted-patient/select-prisoner?searchTerm=Smith')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Select a prisoner')
+          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 3</p>')
+          expect(res.text).toContain(
+            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD) - View Help</a>'
+          )
+          expect(res.text).toContain(
+            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED) - View Help</a>'
           )
         })
     })

--- a/server/routes/addPatient/prisonerSelect.test.ts
+++ b/server/routes/addPatient/prisonerSelect.test.ts
@@ -137,13 +137,13 @@ describe('GET /select-prisoner', () => {
           expect(res.text).toContain('Select a prisoner')
           expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 4</p>')
           expect(res.text).toContain(
-            `<p><span class="govuk-visually-hidden">No add link - determinate sentence past CRD - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+            `<p><span class="govuk-visually-hidden">No add link - determinate sentence past CRD - </span>Ineligible (past CRD)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
           )
           expect(res.text).toContain(
-            `<p><span class="govuk-visually-hidden">No add link - determinate recall past SED - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+            `<p><span class="govuk-visually-hidden">No add link - determinate recall past SED - </span>Ineligible (past SED)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
           )
           expect(res.text).toContain(
-            `<p><span class="govuk-visually-hidden">No add link - not released to a prison - </span>Ineligible (not released to hospital) <a href="/help?section=not-released-to-hospital" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+            `<p><span class="govuk-visually-hidden">No add link - not released to a prison - </span>Ineligible (not released to hospital)<br><a href="/help?section=not-released-to-hospital" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
           )
         })
     })

--- a/server/routes/addPatient/prisonerSelect.test.ts
+++ b/server/routes/addPatient/prisonerSelect.test.ts
@@ -62,7 +62,7 @@ describe('GET /select-prisoner', () => {
         {
           alerts: [],
           locationDescription: 'Outside - released from Doncaster - discharged to NGH',
-          displayName: 'No move link - determinate sentence past CRD',
+          displayName: 'No add link - determinate sentence past CRD',
           formattedAlerts: [],
           prisonerNumber: 'A1234AC',
           lastMovementTypeCode: 'REL',
@@ -75,7 +75,7 @@ describe('GET /select-prisoner', () => {
         {
           alerts: [],
           locationDescription: 'Outside - released from Doncaster - discharged to NGH',
-          displayName: 'No move link - determinate recall past SED',
+          displayName: 'No add link - determinate recall past SED',
           formattedAlerts: [],
           prisonerNumber: 'A1234AD',
           lastMovementTypeCode: 'REL',
@@ -84,6 +84,18 @@ describe('GET /select-prisoner', () => {
           indeterminateSentence: false,
           recall: true,
           sentenceExpiryDate: new Date(new Date().getDate() - 1),
+        } as PrisonerSearchSummary,
+        {
+          alerts: [],
+          locationDescription: 'Outside - released from Doncaster - discharged to NGH',
+          displayName: 'No add link - not released to a prison',
+          formattedAlerts: [],
+          prisonerNumber: 'A1234AE',
+          lastMovementTypeCode: 'REL',
+          lastMovementReasonCode: 'CR',
+          restrictedPatient: false,
+          indeterminateSentence: false,
+          recall: false,
         } as PrisonerSearchSummary,
       ])
     })
@@ -104,7 +116,7 @@ describe('GET /select-prisoner', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain('Select a prisoner')
-          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 3</p>')
+          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 4</p>')
           expect(res.text).toContain(
             '<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />'
           )
@@ -117,18 +129,21 @@ describe('GET /select-prisoner', () => {
         })
     })
 
-    it('should include post CRD and SED but without a move link', () => {
+    it('should include post CRD, post SED and not released to hospital but without an add link', () => {
       return request(app)
         .get('/add-restricted-patient/select-prisoner?searchTerm=Smith')
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain('Select a prisoner')
-          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 3</p>')
+          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 4</p>')
           expect(res.text).toContain(
-            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD) - View Help</a>'
+            `<p><span class="govuk-visually-hidden">No add link - determinate sentence past CRD - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
           )
           expect(res.text).toContain(
-            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED) - View Help</a>'
+            `<p><span class="govuk-visually-hidden">No add link - determinate recall past SED - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+          )
+          expect(res.text).toContain(
+            `<p><span class="govuk-visually-hidden">No add link - not released to a prison - </span>Ineligible (not released to hospital) <a href="/help?section=not-released-to-hospital" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
           )
         })
     })

--- a/server/routes/addPatient/prisonerSelect.ts
+++ b/server/routes/addPatient/prisonerSelect.ts
@@ -57,13 +57,13 @@ export default class PrisonerSelectRoutes {
       return `<a href="/add-restricted-patient/select-hospital?prisonerNumber=${prisoner.prisonerNumber}&journeyStartUrl=/add-restricted-patient/select-prisoner?searchTerm=${searchTerm}" class="govuk-link" data-test="prisoner-add-restricted-patient-link"><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Add to restricted patients</a>`
     }
     if (prisoner.searchStatus === SearchStatus.EXCLUDE_POST_CRD) {
-      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past CRD)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
     }
     if (prisoner.searchStatus === SearchStatus.EXCLUDE_POST_SED) {
-      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past SED)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
     }
     if (prisoner.searchStatus === SearchStatus.EXCLUDE_NOT_RELEASED_HOSPITAL) {
-      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (not released to hospital) <a href="/help?section=not-released-to-hospital" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (not released to hospital)<br><a href="/help?section=not-released-to-hospital" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
     }
     return ''
   }

--- a/server/routes/help/content/issuesHelp.ts
+++ b/server/routes/help/content/issuesHelp.ts
@@ -26,6 +26,15 @@ export default class IssuesHelp implements HelpContent {
         `.trim(),
     },
     {
+      id: 'not-released-to-hospital',
+      category: this.category,
+      heading: `I can't add a released prisoner into the Restricted Patients service as they were not released to hospital.`,
+      content: `
+<p>The page "Add a released prisoner into restricted patients" can be used to add prisoners who were released to a hospital in Classic NOMIS.</p>
+<p>However if the prisoner was not released to hospital then they cannot be added to Restricted Patients. In this situation contact the Support team for advice.</p>
+        `.trim(),
+    },
+    {
       id: 'pom-cannot-find-offender',
       category: this.category,
       heading: 'I am a POM and cannot find my offender who was booked out via the Restricted Patient service.',

--- a/server/routes/movePrisoner/prisonerSelect.test.ts
+++ b/server/routes/movePrisoner/prisonerSelect.test.ts
@@ -95,10 +95,10 @@ describe('GET /select-prisoner', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain(
-            `<p><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+            `<p><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
           )
           expect(res.text).toContain(
-            `<p><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+            `<p><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
           )
         })
     })

--- a/server/routes/movePrisoner/prisonerSelect.test.ts
+++ b/server/routes/movePrisoner/prisonerSelect.test.ts
@@ -95,10 +95,10 @@ describe('GET /select-prisoner', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain(
-            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD) - View Help</a>'
+            `<p><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
           )
           expect(res.text).toContain(
-            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED) - View Help</a>'
+            `<p><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
           )
         })
     })

--- a/server/routes/movePrisoner/prisonerSelect.test.ts
+++ b/server/routes/movePrisoner/prisonerSelect.test.ts
@@ -48,13 +48,24 @@ describe('GET /select-prisoner', () => {
         {
           alerts: [],
           cellLocation: '1-2-016',
-          displayName: 'Excluded - determinate sentence past CRD',
+          displayName: 'No move link - determinate sentence past CRD',
           formattedAlerts: [],
           prisonerNumber: 'A1235AA',
           prisonName: 'HMP Moorland',
           recall: false,
           indeterminateSentence: false,
           conditionalReleaseDate: new Date(new Date().getDate() - 1),
+        } as PrisonerSearchSummary,
+        {
+          alerts: [],
+          cellLocation: '1-2-017',
+          displayName: 'No move link - determinate recall past SED',
+          formattedAlerts: [],
+          prisonerNumber: 'A1236AA',
+          prisonName: 'HMP Moorland',
+          recall: true,
+          indeterminateSentence: false,
+          sentenceExpiryDate: new Date(new Date().getDate() - 1),
         } as PrisonerSearchSummary,
       ])
     })
@@ -65,7 +76,7 @@ describe('GET /select-prisoner', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain('Select a prisoner')
-          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 1</p>')
+          expect(res.text).toContain('<p class="align-right"><strong>People listed:</strong> 3</p>')
           expect(res.text).toContain(
             '<img src="/prisoner/A1234AA/image" alt="Photograph of Smith, John" class="results-table__image" />'
           )
@@ -74,6 +85,20 @@ describe('GET /select-prisoner', () => {
           expect(res.text).toContain('Controlled unlock')
           expect(res.text).toContain(
             '<a href="/move-to-hospital/select-hospital?prisonerNumber=A1234AA&journeyStartUrl=/move-to-hospital/select-prisoner?searchTerm=Smith" class="govuk-link" data-test="prisoner-move-to-hospital-link"><span class="govuk-visually-hidden">Smith, John - </span>Move to a hospital</a>'
+          )
+        })
+    })
+
+    it('should include post CRD and SED but without an add link', () => {
+      return request(app)
+        .get('/move-to-hospital/select-prisoner?searchTerm=Smith')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain(
+            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate sentence past CRD - </span>Ineligible (past CRD) - View Help</a>'
+          )
+          expect(res.text).toContain(
+            '<a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">No move link - determinate recall past SED - </span>Ineligible (past SED) - View Help</a>'
           )
         })
     })

--- a/server/routes/movePrisoner/prisonerSelect.ts
+++ b/server/routes/movePrisoner/prisonerSelect.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import { FormError } from '../../@types/template'
 import PrisonerSearchService, { PrisonerSearchSummary } from '../../services/prisonerSearchService'
 import validateForm from '../searchPrisoners/prisonerSearchValidation'
-import RestrictedPatientSearchFilter from '../searchPatients/restrictedPatientSearchFilter'
+import RestrictedPatientSearchFilter, { SearchStatus } from '../searchPatients/restrictedPatientSearchFilter'
 
 type PageData = {
   error?: FormError
@@ -36,7 +36,11 @@ export default class PrisonerSelectRoutes {
       user
     )
 
-    const availablePrisoners = searchResults.filter(prisoner => this.searchFilter.includePrisonerToMove(prisoner))
+    const availablePrisoners = searchResults
+      .map(prisoner => {
+        return { ...prisoner, searchStatus: this.searchFilter.includePrisonerToMove(prisoner) }
+      })
+      .filter(prisoner => prisoner.searchStatus !== SearchStatus.EXCLUDE)
 
     return this.renderView(req, res, { searchResults: availablePrisoners, searchTerm })
   }

--- a/server/routes/movePrisoner/prisonerSelect.ts
+++ b/server/routes/movePrisoner/prisonerSelect.ts
@@ -60,10 +60,10 @@ export default class PrisonerSelectRoutes {
       return `<a href="/move-to-hospital/select-hospital?prisonerNumber=${prisoner.prisonerNumber}&journeyStartUrl=/move-to-hospital/select-prisoner?searchTerm=${searchTerm}" class="govuk-link" data-test="prisoner-move-to-hospital-link"><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Move to a hospital</a>`
     }
     if (prisoner.searchStatus === SearchStatus.EXCLUDE_POST_CRD) {
-      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past CRD)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
     }
     if (prisoner.searchStatus === SearchStatus.EXCLUDE_POST_SED) {
-      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past SED)<br><a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="restricted_patients_help">View Help</a></p>`
     }
     return ''
   }

--- a/server/routes/movePrisoner/prisonerSelect.ts
+++ b/server/routes/movePrisoner/prisonerSelect.ts
@@ -7,7 +7,6 @@ import RestrictedPatientSearchFilter, { SearchStatus } from '../searchPatients/r
 type PageData = {
   error?: FormError
   searchResults?: PrisonerSearchSummary[]
-  searchTerm: string
 }
 export default class PrisonerSelectRoutes {
   constructor(private readonly prisonerSearchService: PrisonerSearchService) {}
@@ -15,13 +14,11 @@ export default class PrisonerSelectRoutes {
   private searchFilter = new RestrictedPatientSearchFilter()
 
   private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
-    const { error, searchResults, searchTerm } = pageData
+    const { error, searchResults } = pageData
 
     return res.render('pages/movePrisoner/prisonerSelect', {
       errors: error ? [error] : [],
-      journeyStartUrl: `/move-to-hospital/select-prisoner?searchTerm=${searchTerm}`,
       searchResults,
-      searchTerm,
     })
   }
 
@@ -41,8 +38,11 @@ export default class PrisonerSelectRoutes {
         return { ...prisoner, searchStatus: this.searchFilter.includePrisonerToMove(prisoner) }
       })
       .filter(prisoner => prisoner.searchStatus !== SearchStatus.EXCLUDE)
+      .map(prisoner => {
+        return { ...prisoner, actionLink: this.addLink(prisoner, searchTerm) }
+      })
 
-    return this.renderView(req, res, { searchResults: availablePrisoners, searchTerm })
+    return this.renderView(req, res, { searchResults: availablePrisoners })
   }
 
   submit = async (req: Request, res: Response): Promise<void> => {
@@ -50,8 +50,21 @@ export default class PrisonerSelectRoutes {
 
     const error = validateForm({ searchTerm })
 
-    if (error) return this.renderView(req, res, { error, searchTerm })
+    if (error) return this.renderView(req, res, { error })
 
     return res.redirect(`/move-to-hospital/select-prisoner?${new URLSearchParams({ searchTerm })}`)
+  }
+
+  private addLink(prisoner: PrisonerSearchSummary, searchTerm: string): string {
+    if (prisoner.searchStatus === SearchStatus.INCLUDE) {
+      return `<a href="/move-to-hospital/select-hospital?prisonerNumber=${prisoner.prisonerNumber}&journeyStartUrl=/move-to-hospital/select-prisoner?searchTerm=${searchTerm}" class="govuk-link" data-test="prisoner-move-to-hospital-link"><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Move to a hospital</a>`
+    }
+    if (prisoner.searchStatus === SearchStatus.EXCLUDE_POST_CRD) {
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past CRD) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+    }
+    if (prisoner.searchStatus === SearchStatus.EXCLUDE_POST_SED) {
+      return `<p><span class="govuk-visually-hidden">${prisoner.displayName} - </span>Ineligible (past SED) <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link" target="_blank">View Help</a></p>`
+    }
+    return ''
   }
 }

--- a/server/routes/searchPatients/restrictedPatientSearchFilter.test.ts
+++ b/server/routes/searchPatients/restrictedPatientSearchFilter.test.ts
@@ -1,4 +1,4 @@
-import RestrictedPatientSearchFilter from './restrictedPatientSearchFilter'
+import RestrictedPatientSearchFilter, { SearchStatus } from './restrictedPatientSearchFilter'
 import { PrisonerSearchSummary } from '../../services/prisonerSearchService'
 
 const searchFilter = new RestrictedPatientSearchFilter()
@@ -20,7 +20,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: yesterday,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(false)
+      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(SearchStatus.EXCLUDE_POST_CRD)
     })
 
     it('should include determinate sentences before CRD', () => {
@@ -30,7 +30,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: tomorrow,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(true)
+      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(SearchStatus.INCLUDE)
     })
 
     it('should exclude recalls past SED', () => {
@@ -41,7 +41,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: yesterday,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(false)
+      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(SearchStatus.EXCLUDE_POST_SED)
     })
 
     it('should include recalls before SED', () => {
@@ -52,7 +52,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: yesterday,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(true)
+      expect(searchFilter.includePrisonerToMove(prisoner)).toEqual(SearchStatus.INCLUDE)
     })
   })
 
@@ -62,7 +62,7 @@ describe('restrictedPatientSearchFilter', () => {
         restrictedPatient: true,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(false)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.EXCLUDE)
     })
 
     it('should exclude incorrect movements', () => {
@@ -72,7 +72,7 @@ describe('restrictedPatientSearchFilter', () => {
         lastMovementReasonCode: 'CR',
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(false)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.EXCLUDE)
     })
 
     it('should include detained movements', () => {
@@ -82,7 +82,7 @@ describe('restrictedPatientSearchFilter', () => {
         lastMovementReasonCode: 'HO',
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(true)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.INCLUDE)
     })
 
     it('should exclude determinate sentences past CRD', () => {
@@ -95,7 +95,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: yesterday,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(false)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.EXCLUDE_POST_CRD)
     })
 
     it('should include determinate sentences before CRD', () => {
@@ -108,7 +108,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: tomorrow,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(true)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.INCLUDE)
     })
 
     it('should exclude recalls past SED', () => {
@@ -122,7 +122,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: yesterday,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(false)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.EXCLUDE_POST_SED)
     })
 
     it('should include recalls before SED', () => {
@@ -136,7 +136,7 @@ describe('restrictedPatientSearchFilter', () => {
         conditionalReleaseDate: yesterday,
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(true)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.INCLUDE)
     })
   })
 })

--- a/server/routes/searchPatients/restrictedPatientSearchFilter.test.ts
+++ b/server/routes/searchPatients/restrictedPatientSearchFilter.test.ts
@@ -72,7 +72,7 @@ describe('restrictedPatientSearchFilter', () => {
         lastMovementReasonCode: 'CR',
       } as PrisonerSearchSummary
 
-      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.EXCLUDE)
+      expect(searchFilter.includePrisonerToAdd(prisoner)).toEqual(SearchStatus.EXCLUDE_NOT_RELEASED_HOSPITAL)
     })
 
     it('should include detained movements', () => {

--- a/server/routes/searchPatients/restrictedPatientSearchFilter.ts
+++ b/server/routes/searchPatients/restrictedPatientSearchFilter.ts
@@ -1,14 +1,36 @@
 import { PrisonerSearchSummary } from '../../services/prisonerSearchService'
 
-export default class RestrictedPatientSearchFilter {
-  includePrisonerToMove = (prisoner: PrisonerSearchSummary): boolean =>
-    !this.determinateSentenceAfterCRD(prisoner) && !this.recallAfterSED(prisoner)
+// eslint-disable-next-line no-shadow
+export enum SearchStatus {
+  INCLUDE = 'include',
+  EXCLUDE_POST_CRD = 'exclude-post-crd',
+  EXCLUDE_POST_SED = 'exclude-post-sed',
+  EXCLUDE = 'exclude',
+}
 
-  includePrisonerToAdd = (prisoner: PrisonerSearchSummary): boolean =>
-    !prisoner.restrictedPatient &&
-    this.releasedToHospital(prisoner) &&
-    !this.determinateSentenceAfterCRD(prisoner) &&
-    !this.recallAfterSED(prisoner)
+export default class RestrictedPatientSearchFilter {
+  includePrisonerToMove = (prisoner: PrisonerSearchSummary): SearchStatus => {
+    if (this.determinateSentenceAfterCRD(prisoner)) {
+      return SearchStatus.EXCLUDE_POST_CRD
+    }
+    if (this.recallAfterSED(prisoner)) {
+      return SearchStatus.EXCLUDE_POST_SED
+    }
+    return SearchStatus.INCLUDE
+  }
+
+  includePrisonerToAdd = (prisoner: PrisonerSearchSummary): SearchStatus => {
+    if (prisoner.restrictedPatient || !this.releasedToHospital(prisoner)) {
+      return SearchStatus.EXCLUDE
+    }
+    if (this.determinateSentenceAfterCRD(prisoner)) {
+      return SearchStatus.EXCLUDE_POST_CRD
+    }
+    if (this.recallAfterSED(prisoner)) {
+      return SearchStatus.EXCLUDE_POST_SED
+    }
+    return SearchStatus.INCLUDE
+  }
 
   private releasedToHospital = (prisoner: PrisonerSearchSummary): boolean =>
     prisoner.lastMovementTypeCode === 'REL' &&

--- a/server/routes/searchPatients/restrictedPatientSearchFilter.ts
+++ b/server/routes/searchPatients/restrictedPatientSearchFilter.ts
@@ -5,6 +5,7 @@ export enum SearchStatus {
   INCLUDE = 'include',
   EXCLUDE_POST_CRD = 'exclude-post-crd',
   EXCLUDE_POST_SED = 'exclude-post-sed',
+  EXCLUDE_NOT_RELEASED_HOSPITAL = 'exclude-not-released-hospital',
   EXCLUDE = 'exclude',
 }
 
@@ -20,8 +21,11 @@ export default class RestrictedPatientSearchFilter {
   }
 
   includePrisonerToAdd = (prisoner: PrisonerSearchSummary): SearchStatus => {
-    if (prisoner.restrictedPatient || !this.releasedToHospital(prisoner)) {
+    if (prisoner.restrictedPatient) {
       return SearchStatus.EXCLUDE
+    }
+    if (!this.releasedToHospital(prisoner)) {
+      return SearchStatus.EXCLUDE_NOT_RELEASED_HOSPITAL
     }
     if (this.determinateSentenceAfterCRD(prisoner)) {
       return SearchStatus.EXCLUDE_POST_CRD

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -8,10 +8,13 @@ import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
 import { FormattedAlertType, getFormattedAlerts } from '../common/alertFlagValues'
 import { convertToTitleCase } from '../utils/utils'
 import PrisonerResult from '../data/prisonerResult'
+import type { SearchStatus } from '../routes/searchPatients/restrictedPatientSearchFilter'
 
 export interface PrisonerSearchSummary extends PrisonerSearchResult {
   displayName: string
   formattedAlerts: FormattedAlertType[]
+  searchStatus?: SearchStatus
+  actionLink?: string
 }
 
 export interface PrisonerResultSummary extends PrisonerResult {

--- a/server/views/pages/addPatient/releasedPrisonerSelect.njk
+++ b/server/views/pages/addPatient/releasedPrisonerSelect.njk
@@ -35,15 +35,6 @@
     {% set prisonerLinkHtml %}
       <a href="{{ pshUrl }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisoner.displayName }}</a>
     {% endset -%}
-    {% set addReleasedPrisonerLinkHtml %}
-      {% if (prisoner.searchStatus == 'include') %}
-        <a href="/add-restricted-patient/select-hospital?prisonerNumber={{ prisoner.prisonerNumber }}&journeyStartUrl={{ journeyStartUrl }}" class="govuk-link" data-test="prisoner-add-restricted-patient-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Add to restricted patients</a>
-      {% elif (prisoner.searchStatus == 'exclude-post-crd') %}
-        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past CRD) - View Help</a>
-      {% elif (prisoner.searchStatus == 'exclude-post-sed') %}
-        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past SED) - View Help</a>
-      {% endif %}
-    {% endset -%}
     {% set rows = (rows.push([
       { html: prisonerImageHtml },
       {
@@ -55,7 +46,7 @@
       { text: prisoner.prisonerNumber },
       { text: prisoner.locationDescription },
       { html: alertFlags(prisoner.formattedAlerts, newLine=true) + categoryFlag('', prisoner.category, false) },
-      { html: addReleasedPrisonerLinkHtml }
+      { html: prisoner.actionLink }
     ]), rows) %}
   {% endfor %}
 

--- a/server/views/pages/addPatient/releasedPrisonerSelect.njk
+++ b/server/views/pages/addPatient/releasedPrisonerSelect.njk
@@ -36,7 +36,13 @@
       <a href="{{ pshUrl }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisoner.displayName }}</a>
     {% endset -%}
     {% set addReleasedPrisonerLinkHtml %}
-      <a href="/add-restricted-patient/select-hospital?prisonerNumber={{ prisoner.prisonerNumber }}&journeyStartUrl={{ journeyStartUrl }}" class="govuk-link" data-test="prisoner-add-restricted-patient-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Add to restricted patients</a>
+      {% if (prisoner.searchStatus == 'include') %}
+        <a href="/add-restricted-patient/select-hospital?prisonerNumber={{ prisoner.prisonerNumber }}&journeyStartUrl={{ journeyStartUrl }}" class="govuk-link" data-test="prisoner-add-restricted-patient-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Add to restricted patients</a>
+      {% elif (prisoner.searchStatus == 'exclude-post-crd') %}
+        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past CRD) - View Help</a>
+      {% elif (prisoner.searchStatus == 'exclude-post-sed') %}
+        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past SED) - View Help</a>
+      {% endif %}
     {% endset -%}
     {% set rows = (rows.push([
       { html: prisonerImageHtml },

--- a/server/views/pages/movePrisoner/prisonerSelect.njk
+++ b/server/views/pages/movePrisoner/prisonerSelect.njk
@@ -35,17 +35,6 @@
     {% set prisonerLinkHtml %}
       <a href="{{ pshUrl }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisoner.displayName }}</a>
     {% endset -%}
-    {% set moveHospitalLinkHtml %}
-      {% if (prisoner.searchStatus == 'include') %}
-        <a href="/move-to-hospital/select-hospital?prisonerNumber={{ prisoner.prisonerNumber }}&journeyStartUrl={{ journeyStartUrl }}" class="govuk-link" data-test="prisoner-move-to-hospital-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Move to a hospital</a>
-      {% elif (prisoner.searchStatus == 'exclude-post-crd') %}
-        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past CRD) - View Help</a>
-      {% elif (prisoner.searchStatus == 'exclude-post-sed') %}
-        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past SED) - View Help</a>
-      {% else %}
-        <p>Cannot find the prisoner search status: {{ prisoner.searchStatus }}</p>
-      {% endif %}
-    {% endset -%}
     {% set rows = (rows.push([
       { html: prisonerImageHtml },
       {
@@ -57,7 +46,7 @@
       { text: prisoner.prisonerNumber },
       { text: prisoner.cellLocation },
       { html: alertFlags(prisoner.formattedAlerts, newLine=true) + categoryFlag('', prisoner.category, false) },
-      { html: moveHospitalLinkHtml }
+      { html: prisoner.actionLink }
     ]), rows) %}
   {% endfor %}
 

--- a/server/views/pages/movePrisoner/prisonerSelect.njk
+++ b/server/views/pages/movePrisoner/prisonerSelect.njk
@@ -36,7 +36,15 @@
       <a href="{{ pshUrl }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">{{ prisoner.displayName }}</a>
     {% endset -%}
     {% set moveHospitalLinkHtml %}
-      <a href="/move-to-hospital/select-hospital?prisonerNumber={{ prisoner.prisonerNumber }}&journeyStartUrl={{ journeyStartUrl }}" class="govuk-link" data-test="prisoner-move-to-hospital-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Move to a hospital</a>
+      {% if (prisoner.searchStatus == 'include') %}
+        <a href="/move-to-hospital/select-hospital?prisonerNumber={{ prisoner.prisonerNumber }}&journeyStartUrl={{ journeyStartUrl }}" class="govuk-link" data-test="prisoner-move-to-hospital-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Move to a hospital</a>
+      {% elif (prisoner.searchStatus == 'exclude-post-crd') %}
+        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past CRD) - View Help</a>
+      {% elif (prisoner.searchStatus == 'exclude-post-sed') %}
+        <a href="/help?section=restricted-patients-should-be-removed" class="govuk-link" data-test="help-link"><span class="govuk-visually-hidden">{{ prisoner.displayName }} - </span>Ineligible (past SED) - View Help</a>
+      {% else %}
+        <p>Cannot find the prisoner search status: {{ prisoner.searchStatus }}</p>
+      {% endif %}
     {% endset -%}
     {% set rows = (rows.push([
       { html: prisonerImageHtml },


### PR DESCRIPTION
When an offender cannot be added to Restricted Patients because they are no longer the responsibility of a POM, include in the search results but replace the move or add link with a link to the relevant help page section.