### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/hmpps-restricted-patients/Chart.yaml
+++ b/helm_deploy/hmpps-restricted-patients/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-restricted-patients
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.6.5
+    version: "2.7"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.2

--- a/helm_deploy/hmpps-restricted-patients/values.yaml
+++ b/helm_deploy/hmpps-restricted-patients/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-restricted-patients
   productId: DPS066
@@ -7,14 +6,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-restricted-patients
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
     v1_2_enabled: true
     v0_47_enabled: false
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-restricted-patients-cert
     contextColour: green
     path: /
@@ -53,60 +52,10 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    health-kick: "35.177.252.195/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    mojvpn: "81.134.202.29/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    durham-tees-valley: "51.179.197.1/32"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    sodexo4: "51.148.9.201"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webproxy4: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    crc-rrp: "62.253.83.37/32"
-    crc-pp-wwm: "5.153.255.210/32"
-    fivewells-1: "195.89.157.56/29"
-    fivewells-2: "195.59.215.184/29"
-    global-protect: "35.176.93.186/32"
-    petty-france-wifi: "213.121.161.112/28"
-    mojo-azure-landing-zone-public-egress-1: "20.49.214.199/32"
-    mojo-azure-landing-zone-public-egress-2: "20.49.214.228/32"
-    mojo-azure-landing-zone-public-egress-3: "20.26.11.71/32"
-    mojo-azure-landing-zone-public-egress-4: "20.26.11.108/32"
+    groups:
+      - internal
+      - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   targetApplication: hmpps-restricted-patients


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-restricted-patients/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `INTERNAL,PRISONS,PRIVATE_PRISONS`
- The size of the allowlist defined in this file will change: `54 => 0 (54 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- quantum (62.25.109.197/32)
  

- quantum_alt (212.137.36.230/32)
  

- health-kick (35.177.252.195/32)
  

- digitalprisons1 (52.56.112.98/32)
  

- digitalprisons2 (52.56.118.154/32)
  

- j5-phones-1 (35.177.125.252/32)
  

- j5-phones-2 (35.177.137.160/32)
  

- durham-tees-valley (51.179.197.1/32)
  

- interservfls (51.179.196.131/32)
  

- dxc_webproxy1 (195.92.38.20/32)
  

- dxc_webproxy2 (195.92.38.21/32)
  

- dxc_webproxy3 (195.92.38.22/32)
  

- dxc_webprox23 (195.92.38.23/32)
  

- crc-rrp (62.253.83.37/32)
  

- crc-pp-wwm (5.153.255.210/32)
  
